### PR TITLE
Fix heading in Brief history of React

### DIFF
--- a/brief-history-of-react.md
+++ b/brief-history-of-react.md
@@ -1,4 +1,4 @@
-# A Brief History of React
+# A Brief History of React
 
 Why did Facebook create React? What problems does it solve? What was there before? Let's see a little bit of history.
 


### PR DESCRIPTION
There was non-breakable space instead of normal space so Markdown did not parse it as a heading.

```shell
$ hd brief-history-of-react.md | head -n 3
00000000  23 c2 a0 41 20 42 72 69  65 66 20 48 69 73 74 6f  |#..A Brief Histo|
00000010  72 79 20 6f 66 20 52 65  61 63 74 0a 0a 57 68 79  |ry of React..Why|
00000020  20 64 69 64 20 46 61 63  65 62 6f 6f 6b 20 63 72  | did Facebook cr|
```
:point_up: there is `c2 a0` instead normal space `20`
